### PR TITLE
Add Afrezza, Apidra, Levemir, Basaglar and Tresiba profiles, and correct Lantus, Toujeo and Novo Rapid profiles based on more recent data.

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/insulin/InsulinManager.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/insulin/InsulinManager.java
@@ -7,7 +7,6 @@ import com.eveningoutpost.dexdrip.UtilityModels.Pref;
 import com.eveningoutpost.dexdrip.xdrip;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 import java.io.ByteArrayOutputStream;
@@ -53,10 +52,10 @@ public class InsulinManager {
             for (insulinData d : profiles)
                 for (String ppn : d.PPN)
                     if (PPNs.contains(ppn)) {
-                        Log.d(TAG, "pharmacy product number dupplicated " + ppn + ". that's not allowed!");
+                        Log.d(TAG, "Pharmacy product number " + ppn + " is duplicated. That's not allowed!");
                         return false;
                     } else PPNs.add(ppn);
-            Log.d(TAG, "pharmacy product numbers uniquee");
+            Log.d(TAG, "All pharmacy product numbers (PNN) are unique.");
             return true;
         }
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/insulin/InsulinProfileEditor.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/insulin/InsulinProfileEditor.java
@@ -1,6 +1,7 @@
 package com.eveningoutpost.dexdrip.insulin;
 
 import android.os.Bundle;
+import android.view.MotionEvent;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
@@ -8,6 +9,7 @@ import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.LinearLayout;
 import android.widget.Spinner;
+import android.widget.ScrollView;
 
 import com.eveningoutpost.dexdrip.BaseAppCompatActivity;
 import com.eveningoutpost.dexdrip.R;
@@ -31,6 +33,8 @@ public class InsulinProfileEditor extends BaseAppCompatActivity {
     private Spinner basalSpinner, bolusSpinner;
     private HashMap<Insulin, CheckBox> checkboxes;
     private HashMap<String, Insulin> profiles;
+    private ScrollView parentScrollView;
+    private ScrollView childScrollView;
 
     //private Context mContext;
 
@@ -49,6 +53,19 @@ public class InsulinProfileEditor extends BaseAppCompatActivity {
         linearLayout = (LinearLayout) findViewById(R.id.profile_layout_view);
         basalSpinner = (Spinner) findViewById(R.id.basalSpinner);
         bolusSpinner = (Spinner) findViewById(R.id.bolusSpinner);
+        parentScrollView = (ScrollView) findViewById(R.id.parent_scroll_view);
+        childScrollView = (ScrollView) findViewById(R.id.child_scroll_view);
+
+        parentScrollView.setOnTouchListener((v, event) -> {
+            findViewById(R.id.parent_scroll_view).getParent().requestDisallowInterceptTouchEvent(false);
+            return false;
+        });
+
+        childScrollView.setOnTouchListener((v, event) -> {
+            // Disallow the touch request for parent scroll on touch of  child view
+            v.getParent().getParent().requestDisallowInterceptTouchEvent(true);
+            return false;
+        });
 
         for (Insulin i : InsulinManager.getAllProfiles()) {
             LinearLayout v = new LinearLayout(this);

--- a/app/src/main/res/layout/activity_insulinprofile_editor.xml
+++ b/app/src/main/res/layout/activity_insulinprofile_editor.xml
@@ -8,6 +8,7 @@
     android:fitsSystemWindows="true">
 
     <ScrollView
+        android:id="@+id/parent_scroll_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:paddingBottom="@dimen/activity_vertical_margin"
@@ -30,19 +31,29 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:ems="10"
-                android:inputType="textPersonName"
                 android:text="@string/pref_enable_insulinprofiles"
                 android:textSize="18sp" />
 
-            <LinearLayout
-                android:id="@+id/profile_layout_view"
+            <ScrollView
+                android:id="@+id/child_scroll_view"
                 android:layout_width="match_parent"
-                android:layout_height="230dp"
-                android:layout_gravity="top"
-                android:layout_weight="1"
-                android:fadeScrollbars="false"
-                android:orientation="vertical"
-                android:scrollbars="vertical"></LinearLayout>
+                android:layout_height="440dp"
+                android:paddingLeft="@dimen/activity_horizontal_margin"
+                android:paddingTop="@dimen/activity_vertical_margin"
+                android:paddingRight="@dimen/activity_horizontal_margin"
+                android:paddingBottom="@dimen/activity_vertical_margin">
+
+                <LinearLayout
+                    android:id="@+id/profile_layout_view"
+                    android:layout_width="wrap_content"
+                    android:layout_height="440dp"
+                    android:layout_gravity="bottom"
+                    android:layout_weight="1"
+                    android:fadeScrollbars="false"
+                    android:orientation="vertical"
+                    android:scrollbars="vertical"></LinearLayout>
+
+            </ScrollView>
 
             <TextView
                 android:id="@+id/Text2"

--- a/app/src/main/res/raw/insulin_profiles.txt
+++ b/app/src/main/res/raw/insulin_profiles.txt
@@ -135,25 +135,6 @@
         }
       },
       {
-        "name": "Toujeo",
-        "displayName": "Toujeo (long acting)",
-        "PPN":
-        [
-          "ToujeoU100"
-        ],
-        "concentration": "U100",
-        "Curve":
-        {
-          "type": "linear trapezoid",
-          "data":
-          {
-            "onset": "180",
-            "peak": "480",
-            "duration": "2160"
-          }
-        }
-      },
-      {
         "name": "Levemir",
         "displayName": "Levemir (long acting)",
         "PPN":
@@ -168,7 +149,7 @@
           {
             "onset": "60",
             "peak": "180-840",
-            "duration": "1440"
+            "duration": "1500"
           }
         }
       },
@@ -187,7 +168,7 @@
           {
             "onset": "60",
             "peak": "420-1200",
-            "duration": "2160"
+            "duration": "1440"
           }
         }
       },
@@ -207,6 +188,25 @@
             "onset": "60",
             "peak": "480-1140",
             "duration": "1440"
+          }
+        }
+      },
+      {
+        "name": "Toujeo",
+        "displayName": "Toujeo (ultra-long acting)",
+        "PPN":
+        [
+          "ToujeoU100"
+        ],
+        "concentration": "U100",
+        "Curve":
+        {
+          "type": "linear trapezoid",
+          "data":
+          {
+            "onset": "180",
+            "peak": "480-1560",
+            "duration": "2160"
           }
         }
       },

--- a/app/src/main/res/raw/insulin_profiles.txt
+++ b/app/src/main/res/raw/insulin_profiles.txt
@@ -1,233 +1,233 @@
 {
-    "profiles":
-    [
+  "profiles":
+  [
+    {
+      "name": "FIASP",
+      "displayName": "FIASP (ultra-fast acting)",
+      "concentration": "U100",
+      "PPN":
+      [
+        "FIASP-U100"
+      ],
+      "Curve":
       {
-        "name": "FIASP",
-        "displayName": "FIASP (ultra-fast acting)",
-        "concentration": "U100",
-        "PPN":
-        [
-          "FIASP-U100"
-        ],
-        "Curve":
+        "type": "linear trapezoid",
+        "data":
         {
-          "type": "linear trapezoid",
-          "data":
-          {
-            "onset": "2",
-            "peak": "45",
-            "duration": "300"
-          }
-        }
-      },
-      {
-        "name": "Afrezza",
-        "displayName": "Afrezza (inhaled, ultra-fast acting)",
-        "concentration": "U100",
-        "PPN":
-        [
-          "Afrezza-U100"
-        ],
-        "Curve":
-        {
-          "type": "linear trapezoid",
-          "data":
-          {
-            "onset": "5",
-            "peak": "50",
-            "duration": "150"
-          }
-        }
-      },
-      {
-        "name": "Apidra",
-        "displayName": "Apidra (ultra-fast acting)",
-        "concentration": "U100",
-        "PPN":
-        [
-          "Apidra-U100"
-        ],
-        "Curve":
-        {
-          "type": "linear trapezoid",
-          "data":
-          {
-            "onset": "10",
-            "peak": "60-180",
-            "duration": "300"
-          }
-        }
-      },
-      {
-        "name": "Novorapid",
-        "displayName": "Novorapid (rapid acting)",
-        "concentration": "U100",
-        "PPN":
-        [
-          "1100558736"
-        ],
-        "Curve":
-        {
-          "type": "linear trapezoid",
-          "data":
-          {
-            "onset": "10",
-            "peak": "75",
-            "duration": "180"
-          }
-        }
-      },
-      {
-        "name": "Humalog",
-        "displayName": "Humalog (rapid acting)",
-        "concentration": "U100",
-        "PPN":
-        [
-          "Humalog-U100"
-        ],
-        "Curve":
-        {
-          "type": "linear trapezoid",
-          "data":
-          {
-            "onset": "10",
-            "peak": "75",
-            "duration": "180"
-          }
-        }
-      },
-      {
-        "name": "Actrapid",
-        "displayName": "Actrapid (short acting)",
-        "concentration": "U100",
-        "PPN":
-        [
-          "1102949004"
-        ],
-        "Curve":
-        {
-          "type": "linear trapezoid",
-          "data":
-          {
-            "onset": "30",
-            "peak": "60-240",
-            "duration": "480"
-          }
-        }
-      },
-      {
-        "name": "Insulatard",
-        "displayName": "Insulatard (NPH)",
-        "PPN":
-        [
-          "1105039656"
-        ],
-        "concentration": "U100",
-        "Curve":
-        {
-          "type": "linear trapezoid",
-          "data":
-          {
-            "onset": "60",
-            "peak": "120-720",
-            "duration": "1440"
-          }
-        }
-      },
-      {
-        "name": "Levemir",
-        "displayName": "Levemir (long acting)",
-        "PPN":
-        [
-          "LevemirU100"
-        ],
-        "concentration": "U100",
-        "Curve":
-        {
-          "type": "linear trapezoid",
-          "data":
-          {
-            "onset": "60",
-            "peak": "180-840",
-            "duration": "1500"
-          }
-        }
-      },
-      {
-        "name": "Lantus",
-        "displayName": "Lantus (long acting)",
-        "PPN":
-        [
-          "LantusU100"
-        ],
-        "concentration": "U100",
-        "Curve":
-        {
-          "type": "linear trapezoid",
-          "data":
-          {
-            "onset": "60",
-            "peak": "420-1200",
-            "duration": "1440"
-          }
-        }
-      },
-      {
-        "name": "Basaglar",
-        "displayName": "Basaglar (long acting)",
-        "PPN":
-        [
-          "BasaglarU100"
-        ],
-        "concentration": "U100",
-        "Curve":
-        {
-          "type": "linear trapezoid",
-          "data":
-          {
-            "onset": "60",
-            "peak": "480-1140",
-            "duration": "1440"
-          }
-        }
-      },
-      {
-        "name": "Toujeo",
-        "displayName": "Toujeo (ultra-long acting)",
-        "PPN":
-        [
-          "ToujeoU100"
-        ],
-        "concentration": "U100",
-        "Curve":
-        {
-          "type": "linear trapezoid",
-          "data":
-          {
-            "onset": "180",
-            "peak": "480-1560",
-            "duration": "2160"
-          }
-        }
-      },
-      {
-        "name": "Tresiba",
-        "displayName": "Tresiba (ultra-long acting)",
-        "PPN":
-        [
-          "TresibaU100"
-        ],
-        "concentration": "U100",
-        "Curve":
-        {
-          "type": "linear trapezoid",
-          "data":
-          {
-            "onset": "90",
-            "peak": "120-2460",
-            "duration": "2520"
-          }
+          "onset": "2",
+          "peak": "45",
+          "duration": "300"
         }
       }
-    ]
-  }
+    },
+    {
+      "name": "Afrezza",
+      "displayName": "Afrezza (inhaled, ultra-fast acting)",
+      "concentration": "U100",
+      "PPN":
+      [
+        "Afrezza-U100"
+      ],
+      "Curve":
+      {
+        "type": "linear trapezoid",
+        "data":
+        {
+          "onset": "5",
+          "peak": "50",
+          "duration": "150"
+        }
+      }
+    },
+    {
+      "name": "Apidra",
+      "displayName": "Apidra (ultra-fast acting)",
+      "concentration": "U100",
+      "PPN":
+      [
+        "Apidra-U100"
+      ],
+      "Curve":
+      {
+        "type": "linear trapezoid",
+        "data":
+        {
+          "onset": "10",
+          "peak": "60-180",
+          "duration": "300"
+        }
+      }
+    },
+    {
+      "name": "Novorapid",
+      "displayName": "Novorapid (rapid acting)",
+      "concentration": "U100",
+      "PPN":
+      [
+        "1100558736"
+      ],
+      "Curve":
+      {
+        "type": "linear trapezoid",
+        "data":
+        {
+          "onset": "10",
+          "peak": "75",
+          "duration": "180"
+        }
+      }
+    },
+    {
+      "name": "Humalog",
+      "displayName": "Humalog (rapid acting)",
+      "concentration": "U100",
+      "PPN":
+      [
+        "Humalog-U100"
+      ],
+      "Curve":
+      {
+        "type": "linear trapezoid",
+        "data":
+        {
+          "onset": "10",
+          "peak": "75",
+          "duration": "180"
+        }
+      }
+    },
+    {
+      "name": "Actrapid",
+      "displayName": "Actrapid (short acting)",
+      "concentration": "U100",
+      "PPN":
+      [
+        "1102949004"
+      ],
+      "Curve":
+      {
+        "type": "linear trapezoid",
+        "data":
+        {
+          "onset": "30",
+          "peak": "60-240",
+          "duration": "480"
+        }
+      }
+    },
+    {
+      "name": "Insulatard",
+      "displayName": "Insulatard (NPH)",
+      "PPN":
+      [
+        "1105039656"
+      ],
+      "concentration": "U100",
+      "Curve":
+      {
+        "type": "linear trapezoid",
+        "data":
+        {
+          "onset": "60",
+          "peak": "120-720",
+          "duration": "1440"
+        }
+      }
+    },
+    {
+      "name": "Levemir",
+      "displayName": "Levemir (long acting)",
+      "PPN":
+      [
+        "LevemirU100"
+      ],
+      "concentration": "U100",
+      "Curve":
+      {
+        "type": "linear trapezoid",
+        "data":
+        {
+          "onset": "60",
+          "peak": "180-840",
+          "duration": "1500"
+        }
+      }
+    },
+    {
+      "name": "Lantus",
+      "displayName": "Lantus (long acting)",
+      "PPN":
+      [
+        "LantusU100"
+      ],
+      "concentration": "U100",
+      "Curve":
+      {
+        "type": "linear trapezoid",
+        "data":
+        {
+          "onset": "60",
+          "peak": "420-1200",
+          "duration": "1440"
+        }
+      }
+    },
+    {
+      "name": "Basaglar",
+      "displayName": "Basaglar (long acting)",
+      "PPN":
+      [
+        "BasaglarU100"
+      ],
+      "concentration": "U100",
+      "Curve":
+      {
+        "type": "linear trapezoid",
+        "data":
+        {
+          "onset": "60",
+          "peak": "480-1140",
+          "duration": "1440"
+        }
+      }
+    },
+    {
+      "name": "Toujeo",
+      "displayName": "Toujeo (ultra-long acting)",
+      "PPN":
+      [
+        "ToujeoU100"
+      ],
+      "concentration": "U100",
+      "Curve":
+      {
+        "type": "linear trapezoid",
+        "data":
+        {
+          "onset": "180",
+          "peak": "480-1560",
+          "duration": "2160"
+        }
+      }
+    },
+    {
+      "name": "Tresiba",
+      "displayName": "Tresiba (ultra-long acting)",
+      "PPN":
+      [
+        "TresibaU100"
+      ],
+      "concentration": "U100",
+      "Curve":
+      {
+        "type": "linear trapezoid",
+        "data":
+        {
+          "onset": "90",
+          "peak": "120-2460",
+          "duration": "2520"
+        }
+      }
+    }
+  ]
+}

--- a/app/src/main/res/raw/insulin_profiles.txt
+++ b/app/src/main/res/raw/insulin_profiles.txt
@@ -1,138 +1,233 @@
 {
-  "profiles":
-  [
-    {
-      "name": "FIASP",
-      "displayName": "FIASP (ultra fast acting)",
-      "concentration": "U100",
-      "PPN":
-      [
-        "FIASP-U100"
-      ],
-      "Curve":
+    "profiles":
+    [
       {
-        "type": "linear trapezoid",
-        "data":
+        "name": "FIASP",
+        "displayName": "FIASP (ultra-fast acting)",
+        "concentration": "U100",
+        "PPN":
+        [
+          "FIASP-U100"
+        ],
+        "Curve":
         {
-          "onset": "2",
-          "peak": "45",
-          "duration": "300"
+          "type": "linear trapezoid",
+          "data":
+          {
+            "onset": "2",
+            "peak": "45",
+            "duration": "300"
+          }
+        }
+      },
+      {
+        "name": "Afrezza",
+        "displayName": "Afrezza (inhaled, ultra-fast acting)",
+        "concentration": "U100",
+        "PPN":
+        [
+          "Afrezza-U100"
+        ],
+        "Curve":
+        {
+          "type": "linear trapezoid",
+          "data":
+          {
+            "onset": "5",
+            "peak": "50",
+            "duration": "150"
+          }
+        }
+      },
+      {
+        "name": "Apidra",
+        "displayName": "Apidra (ultra-fast acting)",
+        "concentration": "U100",
+        "PPN":
+        [
+          "Apidra-U100"
+        ],
+        "Curve":
+        {
+          "type": "linear trapezoid",
+          "data":
+          {
+            "onset": "10",
+            "peak": "60-180",
+            "duration": "300"
+          }
+        }
+      },
+      {
+        "name": "Novorapid",
+        "displayName": "Novorapid (rapid acting)",
+        "concentration": "U100",
+        "PPN":
+        [
+          "1100558736"
+        ],
+        "Curve":
+        {
+          "type": "linear trapezoid",
+          "data":
+          {
+            "onset": "10",
+            "peak": "75",
+            "duration": "180"
+          }
+        }
+      },
+      {
+        "name": "Humalog",
+        "displayName": "Humalog (rapid acting)",
+        "concentration": "U100",
+        "PPN":
+        [
+          "Humalog-U100"
+        ],
+        "Curve":
+        {
+          "type": "linear trapezoid",
+          "data":
+          {
+            "onset": "10",
+            "peak": "75",
+            "duration": "180"
+          }
+        }
+      },
+      {
+        "name": "Actrapid",
+        "displayName": "Actrapid (short acting)",
+        "concentration": "U100",
+        "PPN":
+        [
+          "1102949004"
+        ],
+        "Curve":
+        {
+          "type": "linear trapezoid",
+          "data":
+          {
+            "onset": "30",
+            "peak": "60-240",
+            "duration": "480"
+          }
+        }
+      },
+      {
+        "name": "Insulatard",
+        "displayName": "Insulatard (NPH)",
+        "PPN":
+        [
+          "1105039656"
+        ],
+        "concentration": "U100",
+        "Curve":
+        {
+          "type": "linear trapezoid",
+          "data":
+          {
+            "onset": "60",
+            "peak": "120-720",
+            "duration": "1440"
+          }
+        }
+      },
+      {
+        "name": "Toujeo",
+        "displayName": "Toujeo (long acting)",
+        "PPN":
+        [
+          "ToujeoU100"
+        ],
+        "concentration": "U100",
+        "Curve":
+        {
+          "type": "linear trapezoid",
+          "data":
+          {
+            "onset": "180",
+            "peak": "480",
+            "duration": "2160"
+          }
+        }
+      },
+      {
+        "name": "Levemir",
+        "displayName": "Levemir (long acting)",
+        "PPN":
+        [
+          "LevemirU100"
+        ],
+        "concentration": "U100",
+        "Curve":
+        {
+          "type": "linear trapezoid",
+          "data":
+          {
+            "onset": "60",
+            "peak": "180-840",
+            "duration": "1440"
+          }
+        }
+      },
+      {
+        "name": "Lantus",
+        "displayName": "Lantus (long acting)",
+        "PPN":
+        [
+          "LantusU100"
+        ],
+        "concentration": "U100",
+        "Curve":
+        {
+          "type": "linear trapezoid",
+          "data":
+          {
+            "onset": "60",
+            "peak": "420-1200",
+            "duration": "2160"
+          }
+        }
+      },
+      {
+        "name": "Basaglar",
+        "displayName": "Basaglar (long acting)",
+        "PPN":
+        [
+          "BasaglarU100"
+        ],
+        "concentration": "U100",
+        "Curve":
+        {
+          "type": "linear trapezoid",
+          "data":
+          {
+            "onset": "60",
+            "peak": "480-1140",
+            "duration": "1440"
+          }
+        }
+      },
+      {
+        "name": "Tresiba",
+        "displayName": "Tresiba (ultra-long acting)",
+        "PPN":
+        [
+          "TresibaU100"
+        ],
+        "concentration": "U100",
+        "Curve":
+        {
+          "type": "linear trapezoid",
+          "data":
+          {
+            "onset": "90",
+            "peak": "120-2460",
+            "duration": "2520"
+          }
         }
       }
-    },
-    {
-      "name": "Novorapid",
-      "displayName": "Novorapid (rapid acting)",
-      "concentration": "U100",
-      "PPN":
-      [
-        "1100558736"
-      ],
-      "Curve":
-      {
-        "type": "linear trapezoid",
-        "data":
-        {
-          "onset": "10",
-          "peak": "75",
-          "duration": "180"
-        }
-      }
-    },
-    {
-      "name": "Humalog",
-      "displayName": "Humalog (rapid acting)",
-      "concentration": "U100",
-      "PPN":
-      [
-        "Humalog-U100"
-      ],
-      "Curve":
-      {
-        "type": "linear trapezoid",
-        "data":
-        {
-          "onset": "10",
-          "peak": "75",
-          "duration": "180"
-        }
-      }
-    },
-    {
-      "name": "Actrapid",
-      "displayName": "Actrapid (short acting)",
-      "concentration": "U100",
-      "PPN":
-      [
-        "1102949004"
-      ],
-      "Curve":
-      {
-        "type": "linear trapezoid",
-        "data":
-        {
-          "onset": "30",
-          "peak": "60-240",
-          "duration": "480"
-        }
-      }
-    },
-    {
-      "name": "Insulatard",
-      "displayName": "Insulatard (NPH)",
-      "PPN":
-      [
-        "1105039656"
-      ],
-      "concentration": "U100",
-      "Curve":
-      {
-        "type": "linear trapezoid",
-        "data":
-        {
-          "onset": "60",
-          "peak": "120-720",
-          "duration": "1440"
-        }
-      }
-    },
-    {
-      "name": "Toujeo",
-      "displayName": "Toujeo (long acting)",
-      "PPN":
-      [
-        "ToujeoU100"
-      ],
-      "concentration": "U100",
-      "Curve":
-      {
-        "type": "linear trapezoid",
-        "data":
-        {
-          "onset": "180",
-          "peak": "480",
-          "duration": "2160"
-        }
-      }
-    },
-    {
-      "name": "Lantus",
-      "displayName": "Lantus (long acting)",
-      "PPN":
-      [
-        "LantusU100"
-      ],
-      "concentration": "U100",
-      "Curve":
-      {
-        "type": "linear trapezoid",
-        "data":
-        {
-          "onset": "60",
-          "peak": "420-1200",
-          "duration": "2160"
-        }
-      }
-    }
-  ]
-}
+    ]
+  }


### PR DESCRIPTION
(see upstream PR for details)